### PR TITLE
grapph Release 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDEA workspace
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # IDEA workspace
 .idea/
+
+# CMAKE build info
+cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # CMAKE build info
 cmake-build-debug/
+
+# ignore build directories
+bin/
+obj/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,8 @@ target_link_libraries(graph_test gtest gtest_main)
 add_executable(set_func_test include/SetFunctions.h
         src/SetFunctionsTest.cpp)
 target_link_libraries(set_func_test gtest gtest_main)
+
+add_executable(homomorphism_test include/Homomorphism.h src/Homomorphism.cpp
+        include/Graph.h src/Graph.cpp
+        src/HomomorphismTest.cpp)
+target_link_libraries(homomorphism_test gtest gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.26)
+project(grapph)
+
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(include)
+
+add_executable(grapph
+        include/Graph.h
+        src/Graph.cpp)
+
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        # Specify the commit you depend on and update it regularly.
+        URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(graph_test include/Graph.h src/Graph.cpp
+        src/GraphTest.cpp)
+target_link_libraries(graph_test gtest gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,3 +18,7 @@ FetchContent_MakeAvailable(googletest)
 add_executable(graph_test include/Graph.h src/Graph.cpp
         src/GraphTest.cpp)
 target_link_libraries(graph_test gtest gtest_main)
+
+add_executable(set_func_test include/SetFunctions.h
+        src/SetFunctionsTest.cpp)
+target_link_libraries(set_func_test gtest gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,6 @@ set(CMAKE_CXX_STANDARD 14)
 
 include_directories(include)
 
-add_executable(grapph
-        include/Graph.h
-        src/Graph.cpp)
-
 include(FetchContent)
 FetchContent_Declare(
         googletest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.2.4
+LIB_VERSION = 0.2.5
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.2.3
+LIB_VERSION = 0.2.4
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.2.2
+LIB_VERSION = 0.2.3
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.2.5
+LIB_VERSION = 0.2.10
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.1.0
+LIB_VERSION = 0.2.1
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj
 BIN_FOLDER = bin
 
-ALL_NAMES = Graph.o
+ALL_NAMES = Graph.o Homomorphism.o
 ALL_OBJS = $(foreach obj, $(ALL_NAMES), $(OBJ_FOLDER)/$(obj))
 
 libgrapph: setup $(ALL_OBJS)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+CCC = g++
+CFLAGS = -Wall -g -fPIC -I./include
+CCFLAGS = -shared
+DFLAGS =
+
+LIB_NAME = libgrapph
+LIB_VERSION = 0.1.0
+
+SRC_FOLDER = src
+OBJ_FOLDER = obj
+BIN_FOLDER = bin
+
+ALL_NAMES = Graph.o
+ALL_OBJS = $(foreach obj, $(ALL_NAMES), $(OBJ_FOLDER)/$(obj))
+
+libgrapph: setup $(ALL_OBJS)
+	$(info -> compiling library)
+	$(CCC) $(CFLAGS) $(CCFLAGS) -o $(BIN_FOLDER)/$(LIB_NAME)_$(LIB_VERSION).a $(ALL_OBJS)
+
+setup:
+	mkdir -p $(BIN_FOLDER) $(OBJ_FOLDER)
+
+clean:
+	rm -f $(OBJ_FOLDER)/* $(BIN_FOLDER)/*
+
+$(ALL_OBJS) : $(OBJ_FOLDER)/%.o : $(SRC_FOLDER)/%.cpp
+	$(info -> $@: compiling object)
+	$(CCC) $(CFLAGS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ BIN_FOLDER = bin
 ALL_NAMES = Graph.o Homomorphism.o
 ALL_OBJS = $(foreach obj, $(ALL_NAMES), $(OBJ_FOLDER)/$(obj))
 
-libgrapph: setup $(ALL_OBJS)
-	$(info -> compiling library)
+lib: setup $(ALL_OBJS)
+	$(info -> compiling libgrapph)
 	$(CCC) $(CFLAGS) $(CCFLAGS) -o $(BIN_FOLDER)/$(LIB_NAME)_$(LIB_VERSION).a $(ALL_OBJS)
 
 setup:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.2.1
+LIB_VERSION = 0.2.2
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 0.2.10
+LIB_VERSION = 1.0.0
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # grapph
-[ACTV] C++ graph encoding
+
+C++ graph encoding library. Feel free to put feature requests or bug reports you find into Issues. I will definitely fix the bugs, and will implement features as I see fit.
+
+## build instructions
+
+Testing done via CMake; to build, just use Makefile. Only `build-essential` required to build on Linux.
+
+For Linux build, use Makefile build targets: `make clean lib`.
+
+Compiled library will be in `bin/`. You should be able to use this like any other library.
+

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -25,6 +25,8 @@ namespace grapph {
 
         void validate(vertex_t);
 
+        std::set<edge_t> getEdgeSpace();
+
     public:
 
         Graph() = default;
@@ -40,6 +42,12 @@ namespace grapph {
 
         std::set<vertex_t> getNeighbors(vertex_t);
         size_t getDegree(vertex_t);
+
+        Graph induce(std::set<vertex_t>&);
+
+        bool contains(Graph&);
+        bool spannedBy(Graph&);
+        bool induces(Graph&);
 
     };
 

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -28,7 +28,9 @@ namespace grapph {
     public:
 
         vertex_t addVertex();
+        vertex_t addVertex(vertex_t);
         edge_t addEdge(vertex_t, vertex_t);
+        edge_t addEdge(edge_t);
 
         bool adjacent(vertex_t, vertex_t);
         bool incident(vertex_t, edge_t);

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -49,6 +49,8 @@ namespace grapph {
         bool spannedBy(Graph&);
         bool induces(Graph&);
 
+        bool equals(Graph&);
+
     };
 
 }

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -25,8 +25,6 @@ namespace grapph {
 
         void validate(vertex_t);
 
-        static std::set<edge_t> getEdgeSpace(std::set<vertex_t>&);
-
     public:
 
         Graph() = default;
@@ -54,8 +52,15 @@ namespace grapph {
 
         bool equals(Graph&);
 
+        static std::set<edge_t> getEdgeSpace(std::set<vertex_t>&);
+
         template <typename T>
-        static bool isInvariant(Graph&, Graph&, T (*)(Graph&));
+        static bool isInvariant(Graph& a, Graph& b, T (*func)(Graph&)) {
+            T aT = func(a);
+            T bT = func(b);
+
+            return aT == bT;
+        }
 
     };
 

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -25,7 +25,7 @@ namespace grapph {
 
         void validate(vertex_t);
 
-        std::set<edge_t> getEdgeSpace();
+        static std::set<edge_t> getEdgeSpace(std::set<vertex_t>&);
 
     public:
 

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -43,6 +43,9 @@ namespace grapph {
         std::set<vertex_t> getNeighbors(vertex_t);
         size_t getDegree(vertex_t);
 
+        std::set<vertex_t> getVertices() { return vertices; }
+        std::set<edge_t> getEdges() { return edges; }
+
         Graph induce(std::set<vertex_t>&);
 
         bool contains(Graph&);

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -18,10 +18,10 @@ namespace grapph {
 
         std::map<vertex_t, std::set<vertex_t>> vertex_neighbors;
 
-        size_t num_vertices;
-        size_t num_edges;
+        size_t num_vertices = 0;
+        size_t num_edges = 0;
 
-        size_t next_vertex;
+        size_t next_vertex = 0;
 
         void validate(vertex_t);
 
@@ -33,7 +33,7 @@ namespace grapph {
         bool adjacent(vertex_t, vertex_t);
         bool incident(vertex_t, edge_t);
 
-        std::set<vertex_t> getNeigbors(vertex_t);
+        std::set<vertex_t> getNeighbors(vertex_t);
         size_t getDegree(vertex_t);
 
     };

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -1,0 +1,44 @@
+//
+// Created by Mason on 1/22/2024.
+//
+
+#ifndef GRAPPH_H
+#define GRAPPH_H
+
+#include <set>
+#include <map>
+
+namespace grapph {
+
+    typedef size_t vertex_t;
+    typedef std::pair<vertex_t, vertex_t> edge_t;
+
+    class Graph {
+
+    private:
+
+        std::set<vertex_t> vertices;
+        std::set<edge_t> edges;
+
+        std::map<vertex_t, std::set<vertex_t>> vertex_neighbors;
+
+        size_t num_vertices;
+        size_t num_edges;
+
+    public:
+
+        Graph();
+
+        vertex_t addVertex();
+        edge_t addEdge(vertex_t, vertex_t);
+
+        bool adjacent(vertex_t, vertex_t);
+        bool incident(vertex_t, edge_t);
+
+        size_t degree(vertex_t);
+
+    };
+
+}
+
+#endif //GRAPPH_VERTEX_H

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -1,7 +1,3 @@
-//
-// Created by Mason on 1/22/2024.
-//
-
 #ifndef GRAPPH_H
 #define GRAPPH_H
 

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -21,6 +21,10 @@ namespace grapph {
         size_t num_vertices;
         size_t num_edges;
 
+        size_t next_vertex;
+
+        void validate(vertex_t);
+
     public:
 
         vertex_t addVertex();
@@ -29,7 +33,8 @@ namespace grapph {
         bool adjacent(vertex_t, vertex_t);
         bool incident(vertex_t, edge_t);
 
-        size_t degree(vertex_t);
+        std::set<vertex_t> getNeigbors(vertex_t);
+        size_t getDegree(vertex_t);
 
     };
 

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -54,6 +54,9 @@ namespace grapph {
 
         bool equals(Graph&);
 
+        template <typename T>
+        static bool isInvariant(Graph&, Graph&, T (*)(Graph&));
+
     };
 
 }

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -23,8 +23,6 @@ namespace grapph {
 
     public:
 
-        Graph();
-
         vertex_t addVertex();
         edge_t addEdge(vertex_t, vertex_t);
 

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -27,6 +27,9 @@ namespace grapph {
 
     public:
 
+        Graph() = default;
+        Graph(std::set<vertex_t>, std::set<edge_t>);
+
         vertex_t addVertex();
         vertex_t addVertex(vertex_t);
         edge_t addEdge(vertex_t, vertex_t);

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -9,7 +9,6 @@ namespace grapph {
 
     typedef std::map<vertex_t, vertex_t>    vfunc_t;
     typedef std::map<edge_t, edge_t>        efunc_t;
-    typedef std::pair<vfunc_t, efunc_t>     homomorphism_t;
 
     class Homomorphism {
 

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -1,0 +1,43 @@
+#ifndef GRAPPH_HOMOMORPHISM_H
+#define GRAPPH_HOMOMORPHISM_H
+
+#include "Graph.h"
+
+#include <map>
+
+namespace grapph {
+
+    typedef std::map<vertex_t, vertex_t>    vfunc_t;
+    typedef std::map<edge_t, edge_t>        efunc_t;
+    typedef std::pair<vfunc_t, efunc_t>     homomorphism_t;
+
+    class Homomorphism {
+
+    private:
+
+        Graph & from;
+        Graph & to;
+
+        vfunc_t vertex_map;
+        efunc_t edge_map;
+
+        void validate();
+
+        bool isInjective();
+        bool isSurjective();
+
+    public:
+
+        Homomorphism(Graph&, Graph&, vfunc_t, efunc_t);
+
+        bool isIsomorphism();
+
+    };
+
+    static vfunc_t compose(vfunc_t, vfunc_t);
+    static efunc_t compose(efunc_t, efunc_t);
+    static Homomorphism compose(Homomorphism, Homomorphism);
+
+}
+
+#endif //GRAPPH_HOMOMORPHISM_H

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -29,8 +29,8 @@ namespace grapph {
         Graph& getFromGraph() { return from; }
         Graph& getToGraph() { return to; }
 
-        vfunc_t getVertexHomomorphism() { return vertex_map; }
-        efunc_t getEdgeHomomorphism() { return edge_map; }
+        vfunc_t getVertexMap() { return vertex_map; }
+        efunc_t getEdgeMap() { return edge_map; }
 
         bool isInjective();
         bool isSurjective();

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -22,19 +22,22 @@ namespace grapph {
 
         void validate();
 
-        bool isInjective();
-        bool isSurjective();
-
     public:
 
         Homomorphism(Graph&, Graph&, vfunc_t, efunc_t);
 
-        bool isIsomorphism();
+        Graph& getFromGraph() { return from; }
+        Graph& getToGraph() { return to; }
+
+        vfunc_t getVertexHomomorphism() { return vertex_map; }
+        efunc_t getEdgeHomomorphism() { return edge_map; }
+
+        bool isInjective();
+        bool isSurjective();
+        bool isBijective();
 
     };
 
-    static vfunc_t compose(vfunc_t, vfunc_t);
-    static efunc_t compose(efunc_t, efunc_t);
     static Homomorphism compose(Homomorphism, Homomorphism);
 
 }

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -24,7 +24,7 @@ namespace grapph {
 
     public:
 
-        Homomorphism(Graph&, Graph&, vfunc_t, efunc_t);
+        Homomorphism(Graph&, Graph&, vfunc_t);
 
         Graph& getFromGraph() { return from; }
         Graph& getToGraph() { return to; }

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -40,6 +40,9 @@ namespace grapph {
 
     static Homomorphism compose(Homomorphism, Homomorphism);
 
+    template <typename T>
+    static bool isInvariant(Graph&, Graph&, T (*)(Graph&));
+
 }
 
 #endif //GRAPPH_HOMOMORPHISM_H

--- a/include/Homomorphism.h
+++ b/include/Homomorphism.h
@@ -36,12 +36,9 @@ namespace grapph {
         bool isSurjective();
         bool isBijective();
 
+        static Homomorphism compose(Homomorphism, Homomorphism);
+
     };
-
-    static Homomorphism compose(Homomorphism, Homomorphism);
-
-    template <typename T>
-    static bool isInvariant(Graph&, Graph&, T (*)(Graph&));
 
 }
 

--- a/include/SetFunctions.h
+++ b/include/SetFunctions.h
@@ -36,7 +36,7 @@ namespace grapph {
         std::set<T> set_difference;
 
         for ( T t : minuend ) {
-            if ( subtrahend.count(t) )  set_difference.insert(t);
+            if ( subtrahend.count(t) == 0 )  set_difference.insert(t);
         }
 
         return set_difference;

--- a/include/SetFunctions.h
+++ b/include/SetFunctions.h
@@ -1,0 +1,47 @@
+#ifndef GRAPPH_SETFUNCTIONS_H
+#define GRAPPH_SETFUNCTIONS_H
+
+#include <set>
+
+namespace grapph {
+
+    template <typename T>
+    static std::set<T> setUnion(std::set<T>& first, std::set<T>& second) {
+        std::set<T> set_union;
+
+        for ( T t : first ) {
+            set_union.insert(t);
+        }
+
+        for ( T t : second ) {
+            set_union.insert(t);
+        }
+
+        return set_union;
+    }
+
+    template <typename T>
+    static std::set<T> setIntersection(std::set<T>& first, std::set<T>& second) {
+        std::set<T> set_intersection;
+
+        for ( T t : first ) {
+            if ( second.count(t) != 0 )  set_intersection.insert(t);
+        }
+
+        return set_intersection;
+    }
+
+    template <typename T>
+    static std::set<T> setDifference(std::set<T>& minuend, std::set<T>& subtrahend) {
+        std::set<T> set_difference;
+
+        for ( T t : minuend ) {
+            if ( subtrahend.count(t) )  set_difference.insert(t);
+        }
+
+        return set_difference;
+    }
+
+}
+
+#endif //GRAPPH_SETFUNCTIONS_H

--- a/include/SetFunctions.h
+++ b/include/SetFunctions.h
@@ -43,7 +43,7 @@ namespace grapph {
     }
 
     template <typename T>
-    static bool containedBy(std::set<T>& sub, std::set<T>& super) {
+    static bool setContains(std::set<T>& super, std::set<T>& sub) {
         for ( T t : sub ) {
             if ( super.count(t) == 0 )  return false;
         }
@@ -52,8 +52,8 @@ namespace grapph {
     }
 
     template <typename T>
-    static bool equals(std::set<T>& a, std::set<T>& b) {
-        return containedBy(a, b) && containedBy(b, a);
+    static bool setEquals(std::set<T>& a, std::set<T>& b) {
+        return setContains(a, b) && setContains(b, a);
     }
 
 }

--- a/include/SetFunctions.h
+++ b/include/SetFunctions.h
@@ -42,6 +42,20 @@ namespace grapph {
         return set_difference;
     }
 
+    template <typename T>
+    static bool containedBy(std::set<T>& sub, std::set<T>& super) {
+        for ( T t : sub ) {
+            if ( super.count(t) == 0 )  return false;
+        }
+
+        return true;
+    }
+
+    template <typename T>
+    static bool equals(std::set<T>& a, std::set<T>& b) {
+        return containedBy(a, b) && containedBy(b, a);
+    }
+
 }
 
 #endif //GRAPPH_SETFUNCTIONS_H

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -1,11 +1,10 @@
 #include "Graph.h"
+#include "SetFunctions.h"
 
 #include <iostream>
 #include <sstream>
 
 #include <stdexcept>
-
-#include <algorithm>
 
 namespace grapph {
 
@@ -19,10 +18,10 @@ namespace grapph {
         }
     }
 
-    std::set<edge_t> Graph::getEdgeSpace() {
+    std::set<edge_t> Graph::getEdgeSpace(std::set<vertex_t>& vertex_set) {
         std::set<edge_t> edge_space;
-        for ( vertex_t i : vertices ) {
-            for ( vertex_t j : vertices ) {
+        for ( vertex_t i : vertex_set ) {
+            for ( vertex_t j : vertex_set ) {
                 if ( i <= j ) { edge_space.insert({i, j}); }
 
             }
@@ -165,7 +164,8 @@ namespace grapph {
         }
 
         // Else, return new induced subgraph
-        Graph induced_subgraph(vertex_subset, {});
+        std::set<edge_t> edge_space = getEdgeSpace(vertex_subset);
+        Graph induced_subgraph(vertex_subset, setIntersection(edges, edge_space));
         for ( edge_t edge : edges ) {
             if ( vertex_subset.count(edge.first) != 0
                     && vertex_subset.count(edge.second) != 0 ) {
@@ -221,15 +221,12 @@ namespace grapph {
         }
 
         // Generate edge space
-        std::set<edge_t> edge_space = induced_subgraph_candidate.getEdgeSpace();
+        std::set<edge_t> edge_space = getEdgeSpace(induced_subgraph_candidate.vertices);
+        std::set<edge_t> induced_subgraph_edges = setIntersection(edges, edge_space);
 
-
-        // Check for each edge in edge space that graph contains => subgraph contains
-        for ( edge_t edge : edge_space ) {
-            if ( edges.count( edge ) != 0
-                    && induced_subgraph_candidate.edges.count( edge ) == 0 ) {
-                return false;
-            }
+        // Verify induced subgraph candidate has necessary edges
+        for ( edge_t edge : induced_subgraph_edges ) {
+            if ( induced_subgraph_candidate.edges.count( edge ) == 0 )  return false;
         }
 
         return true;

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -99,7 +99,8 @@ namespace grapph {
             throw std::invalid_argument("Edge already added");
         }
 
-        // Increment number of edges by 1
+        // Add edge to edge set
+        edges.insert(edge);
         num_edges++;
 
         // Add vertices to each others' incidence lists

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -80,7 +80,7 @@ namespace grapph {
         return vertex == edge.first || vertex == edge.second;
     }
 
-    std::set<vertex_t> Graph::getNeigbors(vertex_t vertex) {
+    std::set<vertex_t> Graph::getNeighbors(vertex_t vertex) {
         // Validate vertex
         validate(vertex);
 

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -5,6 +5,8 @@
 
 #include <stdexcept>
 
+#include <algorithm>
+
 namespace grapph {
 
     void Graph::validate(vertex_t vertex) {
@@ -15,6 +17,17 @@ namespace grapph {
                 << " not found in graph";
             throw std::invalid_argument(ss.str().c_str());
         }
+    }
+
+    std::set<edge_t> Graph::getEdgeSpace() {
+        std::set<edge_t> edge_space;
+        for ( vertex_t i : vertices ) {
+            for ( vertex_t j : vertices ) {
+                edge_space.insert({i, j});
+            }
+        }
+
+        return edge_space;
     }
 
     Graph::Graph(std::set<vertex_t> vertices, std::set<edge_t> edges) {
@@ -130,6 +143,90 @@ namespace grapph {
         validate(vertex);
 
         return vertex_neighbors[vertex].size();
+    }
+
+    Graph Graph::induce(std::set<vertex_t> &vertex_subset) {
+        // Assert vertex subset is proper
+        for ( vertex_t vertex : vertex_subset ) {
+            if ( vertices.count(vertex) == 0 ) {
+                throw std::invalid_argument("Inducing vertex set not subset of graph vertices");
+            }
+        }
+
+        // If subset, but not proper, return self
+        if ( vertex_subset.size() == vertices.size() ) {
+            return *this;
+        }
+
+        // Else, return new induced subgraph
+        Graph induced_subgraph(vertex_subset, {});
+        for ( edge_t edge : edges ) {
+            if ( vertex_subset.count(edge.first) != 0
+                    && vertex_subset.count(edge.second) != 0 ) {
+                induced_subgraph.addEdge(edge);
+            }
+        }
+        return induced_subgraph;
+    }
+
+    bool Graph::contains(Graph & subgraph_candidate) {
+        // Check if each subgraph vertex in graph
+        for ( vertex_t subgraph_vertex : subgraph_candidate.vertices ) {
+            if ( vertices.count(subgraph_vertex) == 0 ) {
+                return false;
+            }
+        }
+
+        // Check if each subgraph edge in graph
+        for ( edge_t subgraph_edge : subgraph_candidate.edges ) {
+            if ( edges.count(subgraph_edge) == 0 ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool Graph::spannedBy(Graph & subgraph_candidate) {
+        // Check if each graph vertex in subgraph
+        if ( num_vertices != subgraph_candidate.num_vertices ) { return false; }
+        for ( vertex_t vertex : vertices ) {
+            if ( subgraph_candidate.vertices.count( vertex ) == 0 ) {
+                return false;
+            }
+        }
+
+        // Check if each subgraph edge in graph
+        for ( edge_t subgraph_edge : subgraph_candidate.edges ) {
+            if ( edges.count(subgraph_edge) == 0 ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool Graph::induces(Graph & induced_subgraph_candidate) {
+        // Check if each subgraph vertex in graph
+        for ( vertex_t subgraph_vertex : induced_subgraph_candidate.vertices ) {
+            if ( vertices.count(subgraph_vertex) == 0 ) {
+                return false;
+            }
+        }
+
+        // Generate edge space
+        std::set<edge_t> edge_space = induced_subgraph_candidate.getEdgeSpace();
+
+
+        // Check for each edge in edge space that graph contains => subgraph contains
+        for ( edge_t edge : edge_space ) {
+            if ( edges.count( edge ) != 0
+                    && induced_subgraph_candidate.edges.count( edge ) == 0 ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -18,18 +18,6 @@ namespace grapph {
         }
     }
 
-    std::set<edge_t> Graph::getEdgeSpace(std::set<vertex_t>& vertex_set) {
-        std::set<edge_t> edge_space;
-        for ( vertex_t i : vertex_set ) {
-            for ( vertex_t j : vertex_set ) {
-                if ( i <= j ) { edge_space.insert({i, j}); }
-
-            }
-        }
-
-        return edge_space;
-    }
-
     Graph::Graph(std::set<vertex_t> vertices, std::set<edge_t> edges) {
         // Add each vertex
         for ( vertex_t vertex : vertices ) {
@@ -194,12 +182,16 @@ namespace grapph {
         return contains(candidate) && candidate.contains(*this);
     }
 
-    template <typename T>
-    bool Graph::isInvariant(Graph& a, Graph& b, T (*func)(Graph&)) {
-        T aT = func(a);
-        T bT = func(b);
+    std::set<edge_t> Graph::getEdgeSpace(std::set<vertex_t>& vertex_set) {
+        std::set<edge_t> edge_space;
+        for ( vertex_t i : vertex_set ) {
+            for ( vertex_t j : vertex_set ) {
+                if ( i < j ) { edge_space.insert({i, j}); }
 
-        return aT == bT;
+            }
+        }
+
+        return edge_space;
     }
 
 }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -198,4 +198,12 @@ namespace grapph {
         return contains(candidate) && candidate.contains(*this);
     }
 
+    template <typename T>
+    bool Graph::isInvariant(Graph& a, Graph& b, T (*func)(Graph&)) {
+        T aT = func(a);
+        T bT = func(b);
+
+        return aT == bT;
+    }
+
 }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -229,4 +229,8 @@ namespace grapph {
         return true;
     }
 
+    bool Graph::equals(Graph & candidate) {
+        return contains(candidate) && candidate.contains(*this);
+    }
+
 }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -167,12 +167,7 @@ namespace grapph {
         // Else, return new induced subgraph
         std::set<edge_t> edge_space = getEdgeSpace(vertex_subset);
         Graph induced_subgraph(vertex_subset, setIntersection(edges, edge_space));
-        for ( edge_t edge : edges ) {
-            if ( vertex_subset.count(edge.first) != 0
-                    && vertex_subset.count(edge.second) != 0 ) {
-                induced_subgraph.addEdge(edge);
-            }
-        }
+
         return induced_subgraph;
     }
 

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -1,0 +1,97 @@
+#include "Graph.h"
+
+#include <iostream>
+#include <sstream>
+
+#include <stdexcept>
+
+namespace grapph {
+
+    void Graph::validate(vertex_t vertex) {
+        if ( vertices.count(vertex) == 0 ) {
+            std::stringstream ss;
+            ss  << "Vertex "
+                << vertex
+                << " not found in graph";
+            throw std::invalid_argument(ss.str().c_str());
+        }
+    }
+
+    vertex_t Graph::addVertex() {
+        // Add new vertex to vertices list
+        vertices.insert(next_vertex);
+
+        // Increase number of vertices by one
+        num_vertices += 1;
+
+        // Initialize vertex neighbors
+        vertex_neighbors[next_vertex] = std::set<vertex_t>();
+
+        // Return new vertex
+        return next_vertex++;
+    }
+
+    edge_t Graph::addEdge(vertex_t first, vertex_t second) {
+        // Ensure vertices both in vertex set
+        validate(first);
+        validate(second);
+
+        // Ensure edge does not already exist
+        if ( vertex_neighbors[first].count(second) != 0 || vertex_neighbors[second].count(first) != 0 ) {
+            throw std::invalid_argument("Edge already added");
+        }
+
+        // Create new edge
+        edge_t edge(first, second);
+        num_edges++;
+
+        // Add vertices to each others' incidence lists
+        vertex_neighbors[first].insert(second);
+        vertex_neighbors[second].insert(first);
+
+        // Return new edge
+        return edge;
+    }
+
+    bool Graph::adjacent(vertex_t first, vertex_t second) {
+        // Validate vertices
+        validate(first);
+        validate(second);
+
+        // Determine whether each vertex considers the other a neighbor
+        bool secondNeighborsFirst = vertex_neighbors[first].count(second) == 1;
+        bool firstNeighborsSecond = vertex_neighbors[second].count(first) == 1;
+
+        // Terminate if vertices disagree on neighborship; should be unreachable
+        if ( firstNeighborsSecond != secondNeighborsFirst ) {
+            std::cerr << "Inconsistency in adjacency data detected; "
+                      << "Terminating with exit code 1" << std::endl;
+            exit(1);
+        }
+
+        // Return result
+        return secondNeighborsFirst;
+    }
+
+    bool Graph::incident(vertex_t vertex, edge_t edge) {
+        // Validate vertex
+        validate(vertex);
+
+        return vertex == edge.first || vertex == edge.second;
+    }
+
+    std::set<vertex_t> Graph::getNeigbors(vertex_t vertex) {
+        // Validate vertex
+        validate(vertex);
+
+        return vertex_neighbors[vertex];
+    }
+
+    size_t Graph::getDegree(vertex_t vertex) {
+        // Validate vertex
+        validate(vertex);
+
+        return vertex_neighbors[vertex].size();
+    }
+
+}

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -176,60 +176,22 @@ namespace grapph {
     }
 
     bool Graph::contains(Graph & subgraph_candidate) {
-        // Check if each subgraph vertex in graph
-        for ( vertex_t subgraph_vertex : subgraph_candidate.vertices ) {
-            if ( vertices.count(subgraph_vertex) == 0 ) {
-                return false;
-            }
-        }
-
-        // Check if each subgraph edge in graph
-        for ( edge_t subgraph_edge : subgraph_candidate.edges ) {
-            if ( edges.count(subgraph_edge) == 0 ) {
-                return false;
-            }
-        }
-
-        return true;
+        return setContains(vertices, subgraph_candidate.vertices)
+                && setContains(edges, subgraph_candidate.edges);
     }
 
     bool Graph::spannedBy(Graph & subgraph_candidate) {
-        // Check if each graph vertex in subgraph
-        if ( num_vertices != subgraph_candidate.num_vertices ) { return false; }
-        for ( vertex_t vertex : vertices ) {
-            if ( subgraph_candidate.vertices.count( vertex ) == 0 ) {
-                return false;
-            }
-        }
-
-        // Check if each subgraph edge in graph
-        for ( edge_t subgraph_edge : subgraph_candidate.edges ) {
-            if ( edges.count(subgraph_edge) == 0 ) {
-                return false;
-            }
-        }
-
-        return true;
+        return setEquals(vertices, subgraph_candidate.vertices)
+                && setContains(edges, subgraph_candidate.edges);
     }
 
     bool Graph::induces(Graph & induced_subgraph_candidate) {
-        // Check if each subgraph vertex in graph
-        for ( vertex_t subgraph_vertex : induced_subgraph_candidate.vertices ) {
-            if ( vertices.count(subgraph_vertex) == 0 ) {
-                return false;
-            }
-        }
-
-        // Generate edge space
+        // Generate edge space and necessary induced subgraph edges
         std::set<edge_t> edge_space = getEdgeSpace(induced_subgraph_candidate.vertices);
         std::set<edge_t> induced_subgraph_edges = setIntersection(edges, edge_space);
 
-        // Verify induced subgraph candidate has necessary edges
-        for ( edge_t edge : induced_subgraph_edges ) {
-            if ( induced_subgraph_candidate.edges.count( edge ) == 0 )  return false;
-        }
-
-        return true;
+        return setContains(vertices, induced_subgraph_candidate.vertices)
+                && setEquals(induced_subgraph_edges, induced_subgraph_candidate.edges);
     }
 
     bool Graph::equals(Graph & candidate) {

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -18,38 +18,64 @@ namespace grapph {
     }
 
     vertex_t Graph::addVertex() {
-        // Add new vertex to vertices list
-        vertices.insert(next_vertex);
-
-        // Increase number of vertices by one
-        num_vertices += 1;
-
-        // Initialize vertex neighbors
-        vertex_neighbors[next_vertex] = std::set<vertex_t>();
+        addVertex(next_vertex);
 
         // Return new vertex
-        return next_vertex++;
+        return next_vertex - 1;
+    }
+
+    vertex_t Graph::addVertex(grapph::vertex_t vertex) {
+        // Ensure vertex not already in vertex set
+        bool fail = true;
+        try {
+            validate(vertex);
+        } catch (std::invalid_argument &iae) {
+            fail = false;
+        }
+        if (fail) {
+            std::stringstream ss;
+            ss  << "Vertex "
+                << vertex
+                << " already in graph";
+            throw std::invalid_argument(ss.str().c_str());
+        }
+
+        // Add new vertex to vertex set
+        vertices.insert(vertex);
+        num_vertices++;
+
+        // Update next vertex
+        next_vertex = next_vertex > vertex ? next_vertex + 1 : vertex + 1;
+
+        // Initialize list of neighbors
+        vertex_neighbors[vertex] = std::set<vertex_t>();
+
+        // Return new vertex
+        return vertex;
     }
 
     edge_t Graph::addEdge(vertex_t first, vertex_t second) {
+        return addEdge({first, second});
+    }
+
+    edge_t Graph::addEdge(edge_t edge) {
         // Ensure vertices both in vertex set
-        validate(first);
-        validate(second);
+        validate(edge.first);
+        validate(edge.second);
 
         // Ensure edge does not already exist
-        if ( vertex_neighbors[first].count(second) != 0 || vertex_neighbors[second].count(first) != 0 ) {
+        if ( vertex_neighbors[edge.first].count(edge.second) != 0
+                || vertex_neighbors[edge.second].count(edge.first) != 0 ) {
             throw std::invalid_argument("Edge already added");
         }
 
-        // Create new edge
-        edge_t edge(first, second);
+        // Increment number of edges by 1
         num_edges++;
 
         // Add vertices to each others' incidence lists
-        vertex_neighbors[first].insert(second);
-        vertex_neighbors[second].insert(first);
+        vertex_neighbors[edge.first].insert(edge.second);
+        vertex_neighbors[edge.second].insert(edge.first);
 
-        // Return new edge
         return edge;
     }
 

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -23,7 +23,8 @@ namespace grapph {
         std::set<edge_t> edge_space;
         for ( vertex_t i : vertices ) {
             for ( vertex_t j : vertices ) {
-                edge_space.insert({i, j});
+                if ( i <= j ) { edge_space.insert({i, j}); }
+
             }
         }
 
@@ -84,6 +85,11 @@ namespace grapph {
     }
 
     edge_t Graph::addEdge(edge_t edge) {
+        // Order edge
+        if ( edge.first > edge.second ) {
+            edge = { edge.second, edge.first };
+        }
+
         // Ensure vertices both in vertex set
         validate(edge.first);
         validate(edge.second);

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -17,6 +17,18 @@ namespace grapph {
         }
     }
 
+    Graph::Graph(std::set<vertex_t> vertices, std::set<edge_t> edges) {
+        // Add each vertex
+        for ( vertex_t vertex : vertices ) {
+            addVertex(vertex);
+        }
+
+        // Add each edge
+        for ( edge_t edge : edges ) {
+            addEdge(edge);
+        }
+    }
+
     vertex_t Graph::addVertex() {
         addVertex(next_vertex);
 

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -259,6 +259,18 @@ TEST(GraphTest, TestEquals) {
     ASSERT_FALSE(iso_s4.equals(eq_s4));
 }
 
+TEST(GraphTest, TestEdgeSpace) {
+    // Initialize...
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2 };
+    std::set<grapph::edge_t> edges = grapph::Graph::getEdgeSpace(vertices);
+
+    // Assertions
+    ASSERT_EQ(3, edges.size());
+    ASSERT_EQ(1, edges.count({ 0, 1 }));
+    ASSERT_EQ(1, edges.count({ 0, 2 }));
+    ASSERT_EQ(1, edges.count({ 1, 2 }));
+}
+
 size_t count_vertices(grapph::Graph & graph) { return graph.getVertices().size(); }
 
 size_t count_edges(grapph::Graph & graph) { return graph.getEdges().size(); }
@@ -277,12 +289,11 @@ std::vector<size_t> degree_score(grapph::Graph & graph) {
 
 bool contains_triangle(grapph::Graph & graph) {
     std::set<grapph::vertex_t> vertices = graph.getVertices();
-    size_t number_of_vertices = vertices.size();
 
     for ( grapph::vertex_t vi : vertices ) {
         for ( grapph::vertex_t vj : vertices ) {
             for ( grapph::vertex_t vk : vertices ) {
-                if ( vi != vj && vi != vk ) {
+                if ( vi != vj && vi != vk && vj != vk ) {
                     std::set<grapph::vertex_t> triangle_vertices = {vi, vj, vk};
                     std::set<grapph::edge_t> triangle_edges = grapph::Graph::getEdgeSpace(triangle_vertices);
                     grapph::Graph triangle(triangle_vertices, triangle_edges);

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -197,3 +197,61 @@ TEST(GraphTest, TestInducesEmpty) {
     ASSERT_TRUE(grapph::setEquals(induced_vertices, actual_vertices));
     ASSERT_TRUE(grapph::setEquals(induced_edges, actual_edges));
 }
+
+TEST(GraphTest, TestSpanning1) {
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4, 5, 6 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {1, 2}, {2, 3},
+                                       {3, 4}, {4, 0}, {3, 5}, {4, 6} };
+    grapph::Graph pentagon_with_tails(vertices, edges);
+
+    // Initialize spanning subgraph
+    std::set<grapph::edge_t> subgraph_edges = { {0, 1}, {1, 2}, {2, 3},
+                                                {3, 4}, {3, 5}, {4, 6} };
+    grapph::Graph subgraph_with_tails(vertices, subgraph_edges);
+
+    // Assertions
+    ASSERT_TRUE(pentagon_with_tails.contains(subgraph_with_tails));
+    ASSERT_TRUE(pentagon_with_tails.spannedBy(subgraph_with_tails));
+    ASSERT_FALSE(pentagon_with_tails.equals(subgraph_with_tails));
+}
+
+TEST(GraphTest, TestSpanning2) {
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4, 5, 6 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {1, 2}, {2, 3},
+                                       {3, 4}, {4, 0}, {3, 5}, {4, 6} };
+    grapph::Graph pentagon_with_tails(vertices, edges);
+
+    // Initialize spanning subgraph
+    std::set<grapph::edge_t> subgraph_edges = {};
+    grapph::Graph empty_spanning_subgraph(vertices, subgraph_edges);
+
+    // Assertions
+    ASSERT_TRUE(pentagon_with_tails.contains(empty_spanning_subgraph));
+    ASSERT_TRUE(pentagon_with_tails.spannedBy(empty_spanning_subgraph));
+    ASSERT_FALSE(pentagon_with_tails.equals(empty_spanning_subgraph));
+}
+
+TEST(GraphTest, TestEquals) {
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {0, 2}, {0, 3}, {0, 4} };
+    grapph::Graph s4(vertices, edges);
+
+    // Initialize equal graph
+    std::set<grapph::edge_t> equal_edges = { {1, 0}, {2, 0}, {3, 0}, {4, 0} };
+    grapph::Graph eq_s4(vertices, equal_edges);
+
+    // Initialize isomorphic, but not equal, graph
+    std::set<grapph::edge_t> isomorphic_edges = { {0, 1}, {2, 1}, {3, 1}, {4, 1} };
+    grapph::Graph iso_s4(vertices, isomorphic_edges);
+
+    // Assertions
+    ASSERT_TRUE(s4.equals(eq_s4));
+    ASSERT_TRUE(eq_s4.equals(s4));
+    ASSERT_FALSE(s4.equals(iso_s4));
+    ASSERT_FALSE(iso_s4.equals(s4));
+    ASSERT_FALSE(eq_s4.equals(iso_s4));
+    ASSERT_FALSE(iso_s4.equals(eq_s4));
+}

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -115,3 +115,85 @@ TEST(GraphTest, TestK3SetBasedSetup) {
     ASSERT_THROW(k3.getNeighbors(4), std::invalid_argument);
 
 }
+
+TEST(GraphTest, TestInduce1) {
+
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {0, 2}, {0, 3}, {0, 4} };
+    grapph::Graph s4(vertices, edges);
+
+    // Induce subgraph
+    std::set<grapph::vertex_t> induced_vertices = { 0, 1, 2, 3 };
+    std::set<grapph::edge_t> induced_edges = { {0, 1}, {0, 2}, {0, 3} };
+    grapph::Graph induced = s4.induce(induced_vertices);
+
+    std::set<grapph::vertex_t> actual_vertices = induced.getVertices();
+    std::set<grapph::edge_t> actual_edges = induced.getEdges();
+
+    // Assertions
+    ASSERT_TRUE(s4.contains(induced));
+    ASSERT_TRUE(s4.induces(induced));
+
+    ASSERT_TRUE(grapph::setEquals(induced_vertices, actual_vertices));
+    ASSERT_TRUE(grapph::setEquals(induced_edges, actual_edges));
+
+}
+
+TEST(GraphTest, TestInduce2) {
+
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {0, 2}, {0, 3}, {0, 4} };
+    grapph::Graph s4(vertices, edges);
+
+    // Induce subgraph
+    std::set<grapph::vertex_t> induced_vertices = { 1, 2, 3, 4 };
+    std::set<grapph::edge_t> induced_edges = {};
+    grapph::Graph induced = s4.induce(induced_vertices);
+
+    std::set<grapph::vertex_t> actual_vertices = induced.getVertices();
+    std::set<grapph::edge_t> actual_edges = induced.getEdges();
+
+    // Assertions
+    ASSERT_TRUE(s4.contains(induced));
+    ASSERT_TRUE(s4.induces(induced));
+
+    ASSERT_TRUE(grapph::setEquals(induced_vertices, actual_vertices));
+    ASSERT_TRUE(grapph::setEquals(induced_edges, actual_edges));
+
+}
+
+TEST(GraphTest, TestInduce3) {
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {0, 2}, {0, 3}, {0, 4} };
+    grapph::Graph s4(vertices, edges);
+
+    std::set<grapph::vertex_t> induced_vertices = { 0, 2, 4, 6 };
+
+    // Assertions
+    ASSERT_THROW(s4.induce(induced_vertices), std::invalid_argument);
+}
+
+TEST(GraphTest, TestInducesEmpty) {
+    // Initialize parent graph
+    std::set<grapph::vertex_t> vertices = { 0, 1, 2, 3, 4 };
+    std::set<grapph::edge_t> edges = { {0, 1}, {0, 2}, {0, 3}, {0, 4} };
+    grapph::Graph s4(vertices, edges);
+
+    // Induce blank subgraph
+    std::set<grapph::vertex_t> induced_vertices = {};
+    std::set<grapph::edge_t> induced_edges = {};
+    grapph::Graph induced = s4.induce(induced_vertices);
+
+    std::set<grapph::vertex_t> actual_vertices = induced.getVertices();
+    std::set<grapph::edge_t> actual_edges = induced.getEdges();
+
+    // Assertions
+    ASSERT_TRUE(s4.contains(induced));
+    ASSERT_TRUE(s4.induces(induced));
+
+    ASSERT_TRUE(grapph::setEquals(induced_vertices, actual_vertices));
+    ASSERT_TRUE(grapph::setEquals(induced_edges, actual_edges));
+}

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -60,3 +60,40 @@ TEST(GraphTest, TestK3BasicSetup) {
     ASSERT_THROW(k3.getNeighbors(4), std::invalid_argument);
 
 }
+
+TEST(GraphTest, TestK3SetBasedSetup) {
+
+    // Initialize graph
+    grapph::Graph k3({0, 2, 3}, {{0, 2}, {0, 3}, {2, 3}});
+
+    ASSERT_EQ(2, k3.getDegree(0));
+    ASSERT_EQ(2, k3.getDegree(2));
+    ASSERT_EQ(2, k3.getDegree(3));
+
+    ASSERT_TRUE(k3.adjacent(0, 2));
+    ASSERT_TRUE(k3.adjacent(0, 3));
+    ASSERT_TRUE(k3.adjacent(2, 3));
+
+    ASSERT_TRUE(k3.incident(0, {0, 2}));
+    ASSERT_TRUE(k3.incident(2, {0, 2}));
+    ASSERT_TRUE(k3.incident(0, {0, 3}));
+    ASSERT_TRUE(k3.incident(3, {0, 3}));
+    ASSERT_TRUE(k3.incident(2, {2, 3}));
+    ASSERT_TRUE(k3.incident(3, {2, 3}));
+
+    ASSERT_EQ(0, k3.getNeighbors(0).count(0));
+    ASSERT_EQ(1, k3.getNeighbors(0).count(2));
+    ASSERT_EQ(1, k3.getNeighbors(0).count(3));
+    ASSERT_EQ(1, k3.getNeighbors(2).count(0));
+    ASSERT_EQ(0, k3.getNeighbors(2).count(2));
+    ASSERT_EQ(1, k3.getNeighbors(2).count(3));
+    ASSERT_EQ(1, k3.getNeighbors(3).count(0));
+    ASSERT_EQ(1, k3.getNeighbors(3).count(2));
+    ASSERT_EQ(0, k3.getNeighbors(3).count(3));
+
+    ASSERT_THROW(k3.addEdge(0, 4), std::invalid_argument);
+    ASSERT_THROW(k3.adjacent(0, 4), std::invalid_argument);
+    ASSERT_THROW(k3.getDegree(4), std::invalid_argument);
+    ASSERT_THROW(k3.getNeighbors(4), std::invalid_argument);
+
+}

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -1,0 +1,62 @@
+#include "gtest/gtest.h"
+
+#include "Graph.h"
+
+TEST(GraphTest, TestK3BasicSetup) {
+
+    // Initialize graph
+    grapph::Graph k3;
+
+    // Add vertices
+    grapph::vertex_t v0 = k3.addVertex();
+    grapph::vertex_t v1 = k3.addVertex();
+    grapph::vertex_t v2 = k3.addVertex();
+
+    // Add edges
+    grapph::edge_t e_0_1 = k3.addEdge(0, 1);
+    grapph::edge_t e_0_2 = k3.addEdge(0, 2);
+    grapph::edge_t e_1_2 = k3.addEdge(1, 2);
+
+    // Assertions
+    ASSERT_EQ(0, v0);
+    ASSERT_EQ(1, v1);
+    ASSERT_EQ(2, v2);
+
+    ASSERT_EQ(0, e_0_1.first);
+    ASSERT_EQ(1, e_0_1.second);
+    ASSERT_EQ(0, e_0_2.first);
+    ASSERT_EQ(2, e_0_2.second);
+    ASSERT_EQ(1, e_1_2.first);
+    ASSERT_EQ(2, e_1_2.second);
+
+    ASSERT_EQ(2, k3.getDegree(v0));
+    ASSERT_EQ(2, k3.getDegree(v1));
+    ASSERT_EQ(2, k3.getDegree(v2));
+
+    ASSERT_TRUE(k3.adjacent(v0, v1));
+    ASSERT_TRUE(k3.adjacent(v0, v2));
+    ASSERT_TRUE(k3.adjacent(v1, v2));
+
+    ASSERT_TRUE(k3.incident(v0, e_0_1));
+    ASSERT_TRUE(k3.incident(v1, e_0_1));
+    ASSERT_TRUE(k3.incident(v0, e_0_2));
+    ASSERT_TRUE(k3.incident(v2, e_0_2));
+    ASSERT_TRUE(k3.incident(v1, e_1_2));
+    ASSERT_TRUE(k3.incident(v2, e_1_2));
+
+    ASSERT_EQ(0, k3.getNeighbors(v0).count(v0));
+    ASSERT_EQ(1, k3.getNeighbors(v0).count(v1));
+    ASSERT_EQ(1, k3.getNeighbors(v0).count(v2));
+    ASSERT_EQ(1, k3.getNeighbors(v1).count(v0));
+    ASSERT_EQ(0, k3.getNeighbors(v1).count(v1));
+    ASSERT_EQ(1, k3.getNeighbors(v1).count(v2));
+    ASSERT_EQ(1, k3.getNeighbors(v2).count(v0));
+    ASSERT_EQ(1, k3.getNeighbors(v2).count(v1));
+    ASSERT_EQ(0, k3.getNeighbors(v2).count(v2));
+
+    ASSERT_THROW(k3.addEdge(v0, 4), std::invalid_argument);
+    ASSERT_THROW(k3.adjacent(v0, 4), std::invalid_argument);
+    ASSERT_THROW(k3.getDegree(4), std::invalid_argument);
+    ASSERT_THROW(k3.getNeighbors(4), std::invalid_argument);
+
+}

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "Graph.h"
+#include "SetFunctions.h"
 
 TEST(GraphTest, TestK3BasicSetup) {
 
@@ -11,11 +12,15 @@ TEST(GraphTest, TestK3BasicSetup) {
     grapph::vertex_t v0 = k3.addVertex();
     grapph::vertex_t v1 = k3.addVertex(2);
     grapph::vertex_t v2 = k3.addVertex();
+    std::set<grapph::vertex_t> vertices = { v0, v1, v2 };
+    std::set<grapph::vertex_t> vertex_set = k3.getVertices();
 
     // Add edges
     grapph::edge_t e_0_1 = k3.addEdge(0, 2);
     grapph::edge_t e_0_2 = k3.addEdge(0, 3);
     grapph::edge_t e_1_2 = k3.addEdge({2, 3});
+    std::set<grapph::edge_t> edges = { e_0_1, e_0_2, e_1_2 };
+    std::set<grapph::edge_t> edge_set = k3.getEdges();
 
     // Assertions
     ASSERT_EQ(0, v0);
@@ -28,6 +33,12 @@ TEST(GraphTest, TestK3BasicSetup) {
     ASSERT_EQ(3, e_0_2.second);
     ASSERT_EQ(2, e_1_2.first);
     ASSERT_EQ(3, e_1_2.second);
+
+    ASSERT_TRUE(grapph::setEquals(vertices, vertex_set));
+    EXPECT_TRUE(grapph::setContains(edges, edge_set));
+    EXPECT_TRUE(grapph::setContains(edge_set, edges));
+    EXPECT_EQ(3, edge_set.size());
+    ASSERT_TRUE(grapph::setEquals(edges, edge_set));
 
     ASSERT_EQ(2, k3.getDegree(v0));
     ASSERT_EQ(2, k3.getDegree(v1));
@@ -64,7 +75,14 @@ TEST(GraphTest, TestK3BasicSetup) {
 TEST(GraphTest, TestK3SetBasedSetup) {
 
     // Initialize graph
-    grapph::Graph k3({0, 2, 3}, {{0, 2}, {0, 3}, {2, 3}});
+    std::set<grapph::vertex_t> vertices = { 0, 2, 3 };
+    std::set<grapph::edge_t> edges = {{0, 2}, {0, 3}, {2, 3}};
+    grapph::Graph k3(vertices, edges);
+    std::set<grapph::vertex_t> vertex_set = k3.getVertices();
+    std::set<grapph::edge_t> edge_set = k3.getEdges();
+
+    ASSERT_TRUE(grapph::setEquals(vertices, vertex_set));
+    ASSERT_TRUE(grapph::setEquals(edges, edge_set));
 
     ASSERT_EQ(2, k3.getDegree(0));
     ASSERT_EQ(2, k3.getDegree(2));

--- a/src/GraphTest.cpp
+++ b/src/GraphTest.cpp
@@ -9,25 +9,25 @@ TEST(GraphTest, TestK3BasicSetup) {
 
     // Add vertices
     grapph::vertex_t v0 = k3.addVertex();
-    grapph::vertex_t v1 = k3.addVertex();
+    grapph::vertex_t v1 = k3.addVertex(2);
     grapph::vertex_t v2 = k3.addVertex();
 
     // Add edges
-    grapph::edge_t e_0_1 = k3.addEdge(0, 1);
-    grapph::edge_t e_0_2 = k3.addEdge(0, 2);
-    grapph::edge_t e_1_2 = k3.addEdge(1, 2);
+    grapph::edge_t e_0_1 = k3.addEdge(0, 2);
+    grapph::edge_t e_0_2 = k3.addEdge(0, 3);
+    grapph::edge_t e_1_2 = k3.addEdge({2, 3});
 
     // Assertions
     ASSERT_EQ(0, v0);
-    ASSERT_EQ(1, v1);
-    ASSERT_EQ(2, v2);
+    ASSERT_EQ(2, v1);
+    ASSERT_EQ(3, v2);
 
     ASSERT_EQ(0, e_0_1.first);
-    ASSERT_EQ(1, e_0_1.second);
+    ASSERT_EQ(2, e_0_1.second);
     ASSERT_EQ(0, e_0_2.first);
-    ASSERT_EQ(2, e_0_2.second);
-    ASSERT_EQ(1, e_1_2.first);
-    ASSERT_EQ(2, e_1_2.second);
+    ASSERT_EQ(3, e_0_2.second);
+    ASSERT_EQ(2, e_1_2.first);
+    ASSERT_EQ(3, e_1_2.second);
 
     ASSERT_EQ(2, k3.getDegree(v0));
     ASSERT_EQ(2, k3.getDegree(v1));

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -109,6 +109,10 @@ namespace grapph {
     }
 
     Homomorphism Homomorphism::compose(Homomorphism first, Homomorphism second) {
+        // Ensure homomorphisms can be composed
+        if ( !first.to.equals(second.from) ) {
+            throw std::invalid_argument("Cannot compose homomorphisms of different graphs -- check order");
+        }
         // Compose vertex homomorphisms
         vfunc_t vertex_map_composition;
         for ( std::pair<vertex_t, vertex_t> mapping : first.getVertexHomomorphism() ) {

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -99,7 +99,7 @@ namespace grapph {
         return isInjective() && isSurjective();
     }
 
-    Homomorphism compose(Homomorphism first, Homomorphism second) {
+    Homomorphism Homomorphism::compose(Homomorphism first, Homomorphism second) {
         // Compose vertex homomorphisms
         vfunc_t vertex_map_composition;
         for ( std::pair<vertex_t, vertex_t> mapping : first.getVertexHomomorphism() ) {
@@ -116,14 +116,6 @@ namespace grapph {
         Homomorphism composed = Homomorphism(first.getFromGraph(), second.getToGraph(),
                                              vertex_map_composition, edge_map_composition);
         return composed;
-    }
-
-    template <typename T>
-    bool isInvariant(Graph& a, Graph& b, T (*func)(Graph&)) {
-        T aT = func(a);
-        T bT = func(b);
-
-        return aT == bT;
     }
 
 }

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -115,8 +115,8 @@ namespace grapph {
         }
         // Compose vertex homomorphisms
         vfunc_t vertex_map_composition;
-        for ( std::pair<vertex_t, vertex_t> mapping : first.getVertexHomomorphism() ) {
-            vertex_map_composition[mapping.first] = second.getVertexHomomorphism()[mapping.second];
+        for ( std::pair<vertex_t, vertex_t> mapping : first.getVertexMap() ) {
+            vertex_map_composition[mapping.first] = second.getVertexMap()[mapping.second];
         }
 
         // Create and return composed homomorphism

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -59,8 +59,18 @@ namespace grapph {
         }
     }
 
-    Homomorphism::Homomorphism(Graph& from, Graph& to, vfunc_t vertex_map, efunc_t edge_map)
-            : from(from), to(to), vertex_map(vertex_map), edge_map(edge_map) {
+    Homomorphism::Homomorphism(Graph& from, Graph& to, vfunc_t vertex_map)
+            : from(from), to(to), vertex_map(vertex_map), edge_map() {
+        for ( edge_t edge : from.getEdges() ) {
+            edge_t mapped_edge = { vertex_map[edge.first], vertex_map[edge.second] };
+            if ( mapped_edge.first > mapped_edge.second ) {
+                vertex_t temp = mapped_edge.first;
+                mapped_edge.first = mapped_edge.second;
+                mapped_edge.second = temp;
+            }
+            edge_map[edge] = mapped_edge;
+        }
+
         validate();
     }
 

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -1,0 +1,121 @@
+#include "Homomorphism.h"
+#include "SetFunctions.h"
+
+#include <sstream>
+
+namespace grapph {
+
+    void Homomorphism::validate() {
+        // Get vertex and edge sets
+        std::set<vertex_t> vertex_domain_expected = from.getVertices();
+        std::set<edge_t> edge_domain_expected = from.getEdges();
+        std::set<vertex_t> vertex_range_superset_expected = to.getVertices();
+        std::set<edge_t> edge_range_superset_expected = to.getEdges();
+
+        // Build homomorphism domains/ranges
+        std::set<vertex_t> vertex_domain;
+        std::set<vertex_t> vertex_range;
+        std::set<edge_t> edge_domain;
+        std::set<edge_t> edge_range;
+        for ( std::pair<vertex_t, vertex_t> mapping : vertex_map ) {
+            vertex_domain.insert(mapping.first);
+            vertex_range.insert(mapping.second);
+        }
+        for ( std::pair<edge_t, edge_t> mapping : edge_map ) {
+            edge_domain.insert(mapping.first);
+            edge_domain.insert(mapping.second);
+        }
+
+        // Verify that domains and ranges are appropriate
+        if ( !setEquals(vertex_domain_expected, vertex_domain) ) {
+            throw std::invalid_argument("Vertex homomorphism does not map every from-vertex");
+        }
+        if ( !setEquals(edge_domain_expected, edge_domain) ) {
+            throw std::invalid_argument("Edge homomorphism does not map every from-edge");
+        }
+        if ( !setContains(vertex_range_superset_expected, vertex_range) ) {
+            throw std::invalid_argument("Vertex homomorphism maps to vertex not in to-vertices");
+        }
+        if ( !setContains(edge_range_superset_expected, edge_range) ) {
+            throw std::invalid_argument("Edge homomorphism maps to vertex not in to-edges");
+        }
+
+        // Verify homomorphism constraint - f_E(uv) = (f_V(u), f_E(v))
+        for ( std::pair<edge_t, edge_t> mapping : edge_map ) {
+            if ( mapping.second.first != vertex_map[mapping.first.first]
+                    || mapping.second.second != vertex_map[mapping.first.second] ) {
+                std::stringstream ss;
+                ss << "Failed homomorphism constraint - f_E(uv) = (f_V(u), f_E(v)) "
+                    << "for u = " << mapping.first.first << " & v = " << mapping.first.second;
+                throw std::invalid_argument(ss.str());
+            }
+        }
+    }
+
+    Homomorphism::Homomorphism(Graph& from, Graph& to, vfunc_t vertex_map, efunc_t edge_map)
+            : from(from), to(to), vertex_map(vertex_map), edge_map(edge_map) {
+        validate();
+    }
+
+    bool Homomorphism::isInjective() {
+        // Assert no two vertices map to same vertex
+        std::set<vertex_t> vertex_range;
+        for ( std::pair<vertex_t, vertex_t> mapping : vertex_map ) {
+            if ( vertex_range.count( mapping.second ) != 0 )  return false;
+            vertex_range.insert( mapping.second );
+        }
+
+        // Assert no two edges map to same edge
+        std::set<edge_t> edge_range;
+        for ( std::pair<edge_t, edge_t> mapping : edge_map ) {
+            if ( edge_range.count( mapping.second ) != 0 )  return false;
+            edge_range.insert( mapping.second );
+        }
+
+        return true;
+    }
+
+    bool Homomorphism::isSurjective() {
+        // Assert every to-vertex in vertex range
+        std::set<vertex_t> vertex_range;
+        for ( std::pair<vertex_t, vertex_t> mapping : vertex_map ) {
+            vertex_range.insert( mapping.second );
+        }
+        std::set<vertex_t> expected_vertex_range = to.getVertices();
+        if ( !setEquals( vertex_range, expected_vertex_range ) )  return false;
+
+        // Assert every to-edge in edge range
+        std::set<edge_t> edge_range;
+        for ( std::pair<edge_t, edge_t> mapping : edge_map ) {
+            edge_range.insert( mapping.second );
+        }
+        std::set<edge_t> expected_edge_range = to.getEdges();
+        if ( !setEquals( edge_range, expected_edge_range ) )  return false;
+
+        return true;
+    }
+
+    bool Homomorphism::isBijective() {
+        return isInjective() && isSurjective();
+    }
+
+    Homomorphism compose(Homomorphism first, Homomorphism second) {
+        // Compose vertex homomorphisms
+        vfunc_t vertex_map_composition;
+        for ( std::pair<vertex_t, vertex_t> mapping : first.getVertexHomomorphism() ) {
+            vertex_map_composition[mapping.first] = second.getVertexHomomorphism()[mapping.second];
+        }
+
+        // Compose edge homomorphisms
+        efunc_t edge_map_composition;
+        for ( std::pair<edge_t, edge_t> mapping : first.getEdgeHomomorphism() ) {
+            edge_map_composition[mapping.first] = second.getEdgeHomomorphism()[mapping.second];
+        }
+
+        // Create and return composed homomorphism
+        Homomorphism composed = Homomorphism(first.getFromGraph(), second.getToGraph(),
+                                             vertex_map_composition, edge_map_composition);
+        return composed;
+    }
+
+}

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -22,8 +22,15 @@ namespace grapph {
             vertex_range.insert(mapping.second);
         }
         for ( std::pair<edge_t, edge_t> mapping : edge_map ) {
+            // First, ensure both edges ordered
+            if ( mapping.first.first > mapping.first.second ) {
+                mapping.first = { mapping.first.second, mapping.first.first };
+            }
+            if ( mapping.second.first > mapping.second.second ) {
+                mapping.second = { mapping.second.second, mapping.second.first };
+            }
             edge_domain.insert(mapping.first);
-            edge_domain.insert(mapping.second);
+            edge_range.insert(mapping.second);
         }
 
         // Verify that domains and ranges are appropriate
@@ -37,7 +44,7 @@ namespace grapph {
             throw std::invalid_argument("Vertex homomorphism maps to vertex not in to-vertices");
         }
         if ( !setContains(edge_range_superset_expected, edge_range) ) {
-            throw std::invalid_argument("Edge homomorphism maps to vertex not in to-edges");
+            throw std::invalid_argument("Edge homomorphism maps to edge not in to-edges");
         }
 
         // Verify homomorphism constraint - f_E(uv) = (f_V(u), f_E(v))

--- a/src/Homomorphism.cpp
+++ b/src/Homomorphism.cpp
@@ -118,4 +118,12 @@ namespace grapph {
         return composed;
     }
 
+    template <typename T>
+    bool isInvariant(Graph& a, Graph& b, T (*func)(Graph&)) {
+        T aT = func(a);
+        T bT = func(b);
+
+        return aT == bT;
+    }
+
 }

--- a/src/HomomorphismTest.cpp
+++ b/src/HomomorphismTest.cpp
@@ -12,14 +12,8 @@ TEST(HomomorphismTest, Homomorphism1) {
     // Create vertex map from s4 to triangle
     grapph::vfunc_t v_map = { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 0 }, { 4, 2 } };
 
-    // Construct edge map
-    grapph::efunc_t e_map;
-    for ( grapph::edge_t edge : pentagon.getEdges() ) {
-        e_map[edge] = { v_map[edge.first], v_map[edge.second] };
-    }
-
     // Construct homomorphism
-    ASSERT_NO_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map, e_map));
+    ASSERT_NO_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map));
 }
 
 TEST(HomomorphismTest, Homomorphism2) {
@@ -31,12 +25,6 @@ TEST(HomomorphismTest, Homomorphism2) {
     // Next, create vertex map for which no homomorphism may exist
     grapph::vfunc_t v_map = { { 0, 0 }, { 1, 0 }, { 2, 1 }, { 3, 2 }, { 4, 1 } };
 
-    // Construct edge map
-    grapph::efunc_t e_map;
-    for ( grapph::edge_t edge : pentagon.getEdges() ) {
-        e_map[edge] = { v_map[edge.first], v_map[edge.second] };
-    }
-
     // Construct homomorphism (should fail)
-    ASSERT_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map, e_map), std::invalid_argument);
+    ASSERT_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map), std::invalid_argument);
 }

--- a/src/HomomorphismTest.cpp
+++ b/src/HomomorphismTest.cpp
@@ -1,0 +1,23 @@
+#include "gtest/gtest.h"
+
+#include "Graph.h"
+#include "Homomorphism.h"
+
+TEST(HomomorphismTest, Homomorphism1) {
+    // First, create two graphs
+    grapph::Graph pentagon({ 0, 1, 2, 3, 4 }, { { 0, 1 }, { 1, 2 }, { 2, 3 },
+                                                { 3, 4 }, { 4, 0 } });
+    grapph::Graph triangle({ 0, 1, 2 }, { { 0, 1 }, { 1, 2 }, { 2, 0 } });
+
+    // Create vertex homomorphism from s4 to triangle
+    grapph::vfunc_t v_homomorphism = { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 0 }, { 4, 2 } };
+
+    // Construct edge homomorphism
+    grapph::efunc_t e_homomorphism;
+    for ( grapph::edge_t edge : pentagon.getEdges() ) {
+        e_homomorphism[edge] = { v_homomorphism[edge.first], v_homomorphism[edge.second] };
+    }
+
+    // Construct homomorphism
+    ASSERT_NO_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_homomorphism, e_homomorphism));
+}

--- a/src/HomomorphismTest.cpp
+++ b/src/HomomorphismTest.cpp
@@ -28,3 +28,101 @@ TEST(HomomorphismTest, Homomorphism2) {
     // Construct homomorphism (should fail)
     ASSERT_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map), std::invalid_argument);
 }
+
+TEST(HomomorphismTest, HomomorphismFeatures1) {
+    // First, create two graphs
+    grapph::Graph pentagon({ 0, 1, 2, 3, 4 }, { { 0, 1 }, { 1, 2 }, { 2, 3 },
+                                                { 3, 4 }, { 4, 0 } });
+    grapph::Graph triangle({ 0, 1, 2 }, { { 0, 1 }, { 1, 2 }, { 2, 0 } });
+
+    // Create vertex map from s4 to triangle
+    grapph::vfunc_t v_map = { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 0 }, { 4, 2 } };
+
+    // Construct homomorphism
+    grapph::Homomorphism hmm(pentagon, triangle, v_map);
+
+    // Assertions
+    ASSERT_FALSE(hmm.isInjective());
+    ASSERT_TRUE(hmm.isSurjective());
+    ASSERT_FALSE(hmm.isBijective());
+}
+
+TEST(HomomorphismTest, HomomorphismFeatures2) {
+    // First, create two graphs
+    grapph::Graph pentagon({ 0, 1, 2, 3, 4 }, { { 0, 1 }, { 1, 2 }, { 2, 3 },
+                                                { 3, 4 }, { 4, 0 } });
+    grapph::Graph p3({ 0, 1, 2, 3 }, { { 0, 1 }, { 1, 2 }, { 2, 3 } });
+
+    // Create a vertex map from p3 to pentagon
+    grapph::vfunc_t v_map = { { 0, 3 }, { 1, 4 }, { 2, 0 }, { 3, 1 } };
+
+    // Construct homomorphism
+    grapph::Homomorphism hmm(p3, pentagon, v_map);
+
+    // Assertions
+    ASSERT_TRUE(hmm.isInjective());
+    ASSERT_FALSE(hmm.isSurjective());
+    ASSERT_FALSE(hmm.isBijective());
+}
+
+TEST(HomomorphismTest, HomomorphismFeatures3) {
+    // First, create two graphs
+    grapph::Graph s4({ 0, 1, 2, 3, 4 }, { {0, 1}, {0, 2}, {0, 3}, {0, 4} });
+    grapph::Graph iso({ 0, 1, 2, 3, 4 }, { {1, 0}, {1, 2}, {1, 3}, {1, 4} });
+
+    // Create a vertex map from s4 to iso
+    grapph::vfunc_t v_map = { {0, 1}, {1, 0}, {2, 3}, {3, 4}, {4, 2} };
+
+    // Construct homomorphism
+    grapph::Homomorphism hmm(s4, iso, v_map);
+
+    // Assertions
+    ASSERT_FALSE(s4.equals(iso));
+    ASSERT_TRUE(hmm.isInjective());
+    ASSERT_TRUE(hmm.isSurjective());
+    ASSERT_TRUE(hmm.isBijective());
+}
+
+TEST(HomomorphismTest, HomomorphismComposition1) {
+    // First, create three graphs
+    grapph::Graph hexagon({ 0, 1, 2, 3, 4, 5 }, { {0, 1}, {1, 2},
+                                                  {2, 3}, {3, 4}, {4, 5}, {5, 0} });
+    grapph::Graph planar({ 0, 1, 2, 3 }, { {0, 1}, {1, 2}, {2, 3}, {3, 0}, {1, 3} });
+    grapph::Graph triangle({ 0, 1, 2 }, { {0, 1}, {1, 2}, {2, 0} });
+
+    // Create vertex map from hexagon to planar
+    grapph::vfunc_t v_h2p = { {0, 0}, {1, 3}, {2, 1}, {3, 3}, {4, 1}, {5, 3} };
+
+    // Create vertex map from planar to triangle
+    grapph::vfunc_t v_p2t = { {0, 0}, {1, 1}, {2, 0}, {3, 2} };
+
+    // Construct homomorphisms
+    grapph::Homomorphism h2p(hexagon, planar, v_h2p);
+    grapph::Homomorphism p2t(planar, triangle, v_p2t);
+
+    // Compose homomorphisms
+    ASSERT_NO_THROW(grapph::Homomorphism::compose(h2p, p2t));
+}
+
+TEST(HomomorphismTest, HomomorphismComposition2) {
+    // First, create four graphs
+    grapph::Graph hexagon({ 0, 1, 2, 3, 4, 5 }, { {0, 1}, {1, 2},
+                                                  {2, 3}, {3, 4}, {4, 5}, {5, 0} });
+    grapph::Graph planar({ 0, 1, 2, 3 }, { {0, 1}, {1, 2}, {2, 3}, {3, 0}, {1, 3} });
+    grapph::Graph pentagon({ 0, 1, 2, 3, 4 }, { { 0, 1 }, { 1, 2 }, { 2, 3 },
+                                                { 3, 4 }, { 4, 0 } });
+    grapph::Graph triangle({ 0, 1, 2 }, { { 0, 1 }, { 1, 2 }, { 2, 0 } });
+
+    // Construct vertex map from hexagon to planar
+    grapph::vfunc_t v_h2p = { {0, 0}, {1, 3}, {2, 1}, {3, 3}, {4, 1}, {5, 3} };
+
+    // Construct vertex map from pentagon to triangle
+    grapph::vfunc_t v_p2t = { {0, 0}, {1, 1}, {2, 2}, {3, 0}, {4, 2} };
+
+    // Construct homomorphisms
+    grapph::Homomorphism h2p(hexagon, planar, v_h2p);
+    grapph::Homomorphism p2t(pentagon, triangle, v_p2t);
+
+    // Compose homomorphisms
+    ASSERT_THROW(grapph::Homomorphism::compose(h2p, p2t), std::invalid_argument);
+}

--- a/src/HomomorphismTest.cpp
+++ b/src/HomomorphismTest.cpp
@@ -9,15 +9,34 @@ TEST(HomomorphismTest, Homomorphism1) {
                                                 { 3, 4 }, { 4, 0 } });
     grapph::Graph triangle({ 0, 1, 2 }, { { 0, 1 }, { 1, 2 }, { 2, 0 } });
 
-    // Create vertex homomorphism from s4 to triangle
-    grapph::vfunc_t v_homomorphism = { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 0 }, { 4, 2 } };
+    // Create vertex map from s4 to triangle
+    grapph::vfunc_t v_map = { { 0, 0 }, { 1, 1 }, { 2, 2 }, { 3, 0 }, { 4, 2 } };
 
-    // Construct edge homomorphism
-    grapph::efunc_t e_homomorphism;
+    // Construct edge map
+    grapph::efunc_t e_map;
     for ( grapph::edge_t edge : pentagon.getEdges() ) {
-        e_homomorphism[edge] = { v_homomorphism[edge.first], v_homomorphism[edge.second] };
+        e_map[edge] = { v_map[edge.first], v_map[edge.second] };
     }
 
     // Construct homomorphism
-    ASSERT_NO_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_homomorphism, e_homomorphism));
+    ASSERT_NO_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map, e_map));
+}
+
+TEST(HomomorphismTest, Homomorphism2) {
+    // First, create two graphs
+    grapph::Graph pentagon({ 0, 1, 2, 3, 4 }, { { 0, 1 }, { 1, 2 }, { 2, 3 },
+                                                { 3, 4 }, { 4, 0 } });
+    grapph::Graph triangle({ 0, 1, 2 }, { { 0, 1 }, { 1, 2 }, { 2, 0 } });
+
+    // Next, create vertex map for which no homomorphism may exist
+    grapph::vfunc_t v_map = { { 0, 0 }, { 1, 0 }, { 2, 1 }, { 3, 2 }, { 4, 1 } };
+
+    // Construct edge map
+    grapph::efunc_t e_map;
+    for ( grapph::edge_t edge : pentagon.getEdges() ) {
+        e_map[edge] = { v_map[edge.first], v_map[edge.second] };
+    }
+
+    // Construct homomorphism (should fail)
+    ASSERT_THROW(grapph::Homomorphism hmm(pentagon, triangle, v_map, e_map), std::invalid_argument);
 }

--- a/src/SetFunctionsTest.cpp
+++ b/src/SetFunctionsTest.cpp
@@ -1,0 +1,46 @@
+#include "gtest/gtest.h"
+
+#include "SetFunctions.h"
+
+TEST(SetFunctionsTest, TestSetEquals1) {
+
+    // Create two equal sets of size_t
+    std::set<size_t> s1 = { 0, 1, 2 };
+    std::set<size_t> s2 = { 0, 1, 2 };
+
+    // Create two different sets of size_t
+    std::set<size_t> d1 = { 0, 1, 2 };
+    std::set<size_t> d2 = { 3, 4, 5 };
+
+    // Assertions
+    ASSERT_TRUE(grapph::setEquals(s1, s2));
+    ASSERT_FALSE(grapph::setEquals(d1, d2));
+
+}
+
+TEST(SetFunctionsTest, TestSetEquals2) {
+
+    // Create two equal bool sets
+    std::set<bool> s1 = { true, true };
+    std::set<bool> s2 = { true };
+
+    // Create two different bool sets
+    std::set<bool> d1 = { true };
+    std::set<bool> d2 = { false };
+
+    // Assertions
+    ASSERT_TRUE(grapph::setEquals(s1, s2));
+    ASSERT_FALSE(grapph::setEquals(d1, d2));
+
+}
+
+TEST(SetFunctionsTest, TestSetEquals3) {
+
+    // Create two different size_t sets
+    std::set<size_t> d1 = {};
+    std::set<size_t> d2 = { 0 };
+
+    // Assertions
+    ASSERT_FALSE(grapph::setEquals(d1, d2));
+
+}

--- a/src/SetFunctionsTest.cpp
+++ b/src/SetFunctionsTest.cpp
@@ -80,3 +80,86 @@ TEST(SetFunctionsTest, TestSetContainment3) {
     ASSERT_FALSE(grapph::setContains(sub, sup));
 
 }
+
+TEST(SetFunctionsTest, TestSetUnion1) {
+
+    // Create two identical size_t sets
+    std::set<size_t> s1 = { 0, 1, 2 };
+    std::set<size_t> s2 = { 0, 1, 2 };
+
+    // Create a different size_t set
+    std::set<size_t> d1 = { 1, 2, 3 };
+
+    // Union sets
+    std::set<size_t> u1 = grapph::setUnion(s1, s2);
+    std::set<size_t> u2 = grapph::setUnion(s1, d1);
+
+    // Assertions
+    ASSERT_TRUE(grapph::setEquals(s1, u1));
+    ASSERT_TRUE(grapph::setEquals(s2, u1));
+    ASSERT_TRUE(grapph::setContains(u2, s1));
+    ASSERT_TRUE(grapph::setContains(u2, d1));
+    ASSERT_NE(s1.size() + d1.size(), u2.size());
+
+}
+
+TEST(SetFunctionsTest, TestSetIntersection1) {
+
+    // Create two identical size_t sets
+    std::set<size_t> s1 = { 0, 1, 2 };
+    std::set<size_t> s2 = { 0, 1, 2 };
+
+    // Create a different size_t set
+    std::set<size_t> d1 = { 1, 2, 3 };
+
+    // Intersect sets
+    std::set<size_t> i1 = grapph::setIntersection(s1, s2);
+    std::set<size_t> i2 = grapph::setIntersection(s1, d1);
+
+    // Assertions
+    ASSERT_TRUE(grapph::setEquals(s1, i1));
+    ASSERT_EQ(2, i2.size());
+    ASSERT_TRUE(grapph::setContains(s1, i2));
+    ASSERT_TRUE(grapph::setContains(d1, i2));
+
+}
+
+TEST(SetFunctionsTest, TestSetDifference1) {
+
+    // Create two size_t sets
+    std::set<size_t> a = { 0, 1, 2, 3 };
+    std::set<size_t> b = { 1, 2 };
+
+    // Subtract sets
+    std::set<size_t> diff = grapph::setDifference(a, b);
+    std::set<size_t> backwards = grapph::setDifference(b, a);
+
+    // Assertions
+    ASSERT_TRUE(grapph::setContains(a, diff));
+    ASSERT_FALSE(grapph::setContains(b, diff));
+    ASSERT_TRUE(grapph::setContains(a, b));
+    ASSERT_EQ(a.size() - b.size(), diff.size());
+    ASSERT_EQ(0, backwards.size());
+    ASSERT_TRUE(grapph::setContains(b, backwards));
+
+}
+
+TEST(SetFunctionsTest, TestSetDifference2) {
+
+    // Create two size_t sets
+    std::set<size_t> a = { 0, 1, 2, 3 };
+    std::set<size_t> b = { 1, 2, 4 };
+
+    // Subtract sets
+    std::set<size_t> diff = grapph::setDifference(a, b);
+    std::set<size_t> backwards = grapph::setDifference(b, a);
+
+    // Assertions
+    ASSERT_TRUE(grapph::setContains(a, diff));
+    ASSERT_FALSE(grapph::setContains(b, diff));
+    ASSERT_FALSE(grapph::setContains(a, b));
+    ASSERT_NE(a.size() - b.size(), diff.size());
+    ASSERT_EQ(1, backwards.size());
+    ASSERT_TRUE(grapph::setContains(b, backwards));
+
+}

--- a/src/SetFunctionsTest.cpp
+++ b/src/SetFunctionsTest.cpp
@@ -44,3 +44,39 @@ TEST(SetFunctionsTest, TestSetEquals3) {
     ASSERT_FALSE(grapph::setEquals(d1, d2));
 
 }
+
+TEST(SetFunctionsTest, TestSetContainment1) {
+
+    // Create two size_t sets with containment relation
+    std::set<size_t> sub = { 0, 1 };
+    std::set<size_t> sup = { 0, 1, 2, 3 };
+
+    // Assertions
+    ASSERT_TRUE(grapph::setContains(sup, sub));
+    ASSERT_FALSE(grapph::setContains(sub, sup));
+
+}
+
+TEST(SetFunctionsTest, TestSetContainment2) {
+
+    // Create two bool sets with containment relation
+    std::set<bool> sub = { false };
+    std::set<bool> sup = { true, false };
+
+    // Assertions
+    ASSERT_TRUE(grapph::setContains(sup, sub));
+    ASSERT_FALSE(grapph::setContains(sub, sup));
+
+}
+
+TEST(SetFunctionsTest, TestSetContainment3) {
+
+    // Create two bool sets with containment relation
+    std::set<bool> sub = {};
+    std::set<bool> sup = { true, false };
+
+    // Assertions
+    ASSERT_TRUE(grapph::setContains(sup, sub));
+    ASSERT_FALSE(grapph::setContains(sub, sup));
+
+}


### PR DESCRIPTION
After a few days of hard work, I finally have a version of this library that I'm happy with! grapph is a C++ library that is used for the representation of undirected graphs with emphasis on mathematical rigor. Graphs are one of the most important abstractions in all of computer science, so I wanted to make a well-defined and well-tested implementation of them that I, and others, can use in projects. Here's a list of major release features:

* A header-only collection of `grapph` functions on `std::set<T>`s that do the following:
  * take the union of two `std::set<T>`s
  * find the intersection between two `std::set<T>`s
  * find the difference between two `std::set<T>`s
  * check if one `std::set<T>` is the subset of another `std::set<T>` (may not be reliable for floating points
  * check if two `std::set<T>`s are equal
* `grapph::Graph` data structure, encoding vertices (`vertex_t` type defined as `size_t`) and edges (`edge_t` defined as `std::pair<vertex_t, vertex_t>`) of an undirected graph, as well as functionality to help do the following:
  * check if two `grapph::vertex_t`s are adjacent
  * check if a `grapph::vertex_t` is incident to an edge
  * get all of the (open) neighbors of a `grapph::vertex_t`
  * get the degree of a `vertex_t`
  * induce a subgraph from a `std::set<vertex_t>`
  * check if one `grapph::Graph` contains another `grapph::Graph`
  * check if one `grapph::Graph` spans another `grapph::Graph`
  * check if one `grapph::Graph` induces another `grapph::Graph`
  * check if two `grapph::Graph`s are equal
  * from a `std::set<vertex_t>`, generate a list of all possible `edge_t`s between distinct `vertex_t`s
  * check graph invariance between two graphs by supplying a function pointer `T (*)(grapph::Graph&)` that, given a `grapph::Graph`, returns some `T` (not well defined if `T` is not overloaded with `==` or `T` is floating point)
* `grapph::Homomorphism` data structure that, given two `grapph::Graph`s and a proposed `vfunc_t` (defined as `std::map<vertex_t, vertex_t>`), does the following:
  * determines whether or not the supplied `vfunc_t` is a homomorphism; if not, raises a `std::invalid_argument` explaining why
  * constructs a `efunc_t` (defined as `std::map<edge_t, edge_t>` to simplify mapping of homomorphic edges
  * will tell you whether the constructed `grapph::Homomorphism` is injective, surjective, or bijective
  * can be composed with another `grapph::Homomorphism`, assuming correct first `grapph::Homorphism`'s to-graph is the same as the second `grapph::Homomorphism`'s from-graph
* Well-documented tests in `src/` directory
* Makefile for library building so that only `build-essential` required on Linux