### PR TITLE
included cstddef for pickier compilers #9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-CCC = g++
+CCC = g++ -std=c++17
 CFLAGS = -Wall -g -fPIC -I./include
 CCFLAGS = -shared
 DFLAGS =
 
 LIB_NAME = libgrapph
-LIB_VERSION = 2.0.0
+LIB_VERSION = 2.0.1
 
 SRC_FOLDER = src
 OBJ_FOLDER = obj

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -1,6 +1,8 @@
 #ifndef GRAPPH_H
 #define GRAPPH_H
 
+#include <cstddef>
+
 #include <set>
 #include <map>
 


### PR DESCRIPTION
Recently switched from an Ubuntu workspace to Windows/Debian (WSL) and ran into trouble compiling with `size_t`, resulting in an open of #9.

I thought I would need to refactor `size_t` to `std::size_t`, but ended up being able to fix this by including `<cstddef>` in the header of my top-level data structure, `Graph`.